### PR TITLE
Fix kernel memory leak in Vivante GPU driver

### DIFF
--- a/drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_os.c
+++ b/drivers/mxc/gpu-viv/hal/os/linux/kernel/gc_hal_kernel_os.c
@@ -5049,9 +5049,13 @@ OnError:
                         if (!((physical - Os->device->baseAddress) & 0x80000000))
                         {
                             gctPHYS_ADDR_T gpuPhysical;
+
+                            kfree(ref);
+                            ref = gcvNULL;
+                            info->ref = gcvNULL;
+
                             kfree(pages);
                             pages = gcvNULL;
-
                             info->pages = gcvNULL;
                             info->pageTable = gcvNULL;
 


### PR DESCRIPTION
We had a kernel memory leak each time we started a video on our PPC-4218 board.
We could see the leak occured on kmalloc-4096 blocks using slabtop.
